### PR TITLE
feat: grpc impl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,16 @@
 !*.md
 !*.cpp
 !*.cmake
+!*.proto
 !.gitignore
 !.clang-format
 !CMakeLists.txt
 
 !tests/
 !server/
+!server/common/
+!server/proto/
+
 !sdk/
 !sdk/include/
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,0 +1,76 @@
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# cmake build file for C++ helloworld example.
+# Assumes protobuf and gRPC have been installed using cmake.
+# See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
+# that automatically builds all the dependencies before building helloworld.
+
+cmake_minimum_required(VERSION 3.5.1)
+
+set(GRPC_FETCHCONTENT OFF)
+set(GRPC_AS_SUBMODULE OFF)
+
+include(cmake/common.cmake)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Proto file
+get_filename_component(hw_proto "./proto/algointerface.proto" ABSOLUTE)
+get_filename_component(hw_proto_path "${hw_proto}" PATH)
+
+# Generated sources
+set(hw_proto_srcs "${CMAKE_BINARY_DIR}/algointerface.pb.cc")
+set(hw_proto_hdrs "${CMAKE_BINARY_DIR}/algointerface.pb.h")
+set(hw_grpc_srcs "${CMAKE_BINARY_DIR}/algointerface.grpc.pb.cc")
+set(hw_grpc_hdrs "${CMAKE_BINARY_DIR}/algointerface.grpc.pb.h")
+add_custom_command(
+      OUTPUT "${hw_proto_srcs}" "${hw_proto_hdrs}" "${hw_grpc_srcs}" "${hw_grpc_hdrs}"
+      COMMAND ${_PROTOBUF_PROTOC}
+      ARGS --grpc_out "${CMAKE_BINARY_DIR}"
+        --cpp_out "${CMAKE_BINARY_DIR}"
+        -I "${hw_proto_path}"
+        --plugin=protoc-gen-grpc="${_GRPC_CPP_PLUGIN_EXECUTABLE}"
+        "${hw_proto}"
+      DEPENDS "${hw_proto}")
+
+# Include generated *.pb.h files
+include_directories("${CMAKE_BINARY_DIR}")
+
+# hw_grpc_proto
+add_library(${PROJECT_NAME}
+    ${hw_grpc_srcs}
+    ${hw_grpc_hdrs}
+    ${hw_proto_srcs}
+    ${hw_proto_hdrs}
+    grpc_server.cpp
+)
+
+target_include_directories(${PROJECT_NAME}
+PUBLIC
+    include
+    ${PROJECT_SOURCE_DIR}/src
+    ${OpenCV_INCLUDE_DIR}
+)
+
+target_link_libraries(${PROJECT_NAME}
+    ${_REFLECTION}
+    ${_GRPC_GRPCPP}
+    ${_PROTOBUF_LIBPROTOBUF}
+    ${OpenCV_LIBS}
+    plog
+    blob-sdk-module
+)

--- a/server/cmake/common.cmake
+++ b/server/cmake/common.cmake
@@ -1,0 +1,124 @@
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# cmake build file for C++ route_guide example.
+# Assumes protobuf and gRPC have been installed using cmake.
+# See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
+# that automatically builds all the dependencies before building route_guide.
+
+cmake_minimum_required(VERSION 3.5.1)
+
+set (CMAKE_CXX_STANDARD 11)
+
+if(MSVC)
+  add_definitions(-D_WIN32_WINNT=0x600)
+endif()
+
+find_package(Threads REQUIRED)
+
+if(GRPC_AS_SUBMODULE)
+  # One way to build a projects that uses gRPC is to just include the
+  # entire gRPC project tree via "add_subdirectory".
+  # This approach is very simple to use, but the are some potential
+  # disadvantages:
+  # * it includes gRPC's CMakeLists.txt directly into your build script
+  #   without and that can make gRPC's internal setting interfere with your
+  #   own build.
+  # * depending on what's installed on your system, the contents of submodules
+  #   in gRPC's third_party/* might need to be available (and there might be
+  #   additional prerequisites required to build them). Consider using
+  #   the gRPC_*_PROVIDER options to fine-tune the expected behavior.
+  #
+  # A more robust approach to add dependency on gRPC is using
+  # cmake's ExternalProject_Add (see cmake_externalproject/CMakeLists.txt).
+
+  # Include the gRPC's cmake build (normally grpc source code would live
+  # in a git submodule called "third_party/grpc", but this example lives in
+  # the same repository as gRPC sources, so we just look a few directories up)
+  add_subdirectory(../../.. ${CMAKE_CURRENT_BINARY_DIR}/grpc EXCLUDE_FROM_ALL)
+  message(STATUS "Using gRPC via add_subdirectory.")
+
+  # After using add_subdirectory, we can now use the grpc targets directly from
+  # this build.
+  set(_PROTOBUF_LIBPROTOBUF libprotobuf)
+  set(_REFLECTION grpc++_reflection)
+  if(CMAKE_CROSSCOMPILING)
+    find_program(_PROTOBUF_PROTOC protoc)
+  else()
+    set(_PROTOBUF_PROTOC $<TARGET_FILE:protobuf::protoc>)
+  endif()
+  set(_GRPC_GRPCPP grpc++)
+  if(CMAKE_CROSSCOMPILING)
+    find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+  else()
+    set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:grpc_cpp_plugin>)
+  endif()
+elseif(GRPC_FETCHCONTENT)
+  # Another way is to use CMake's FetchContent module to clone gRPC at
+  # configure time. This makes gRPC's source code available to your project,
+  # similar to a git submodule.
+  message(STATUS "Using gRPC via add_subdirectory (FetchContent).")
+  include(FetchContent)
+  FetchContent_Declare(
+    grpc
+    GIT_REPOSITORY https://github.com/grpc/grpc.git
+    # when using gRPC, you will actually set this to an existing tag, such as
+    # v1.25.0, v1.26.0 etc..
+    # For the purpose of testing, we override the tag used to the commit
+    # that's currently under test.
+    GIT_TAG        v1.41.1
+    GIT_SHALLOW ON)
+  FetchContent_MakeAvailable(grpc)
+
+  # Since FetchContent uses add_subdirectory under the hood, we can use
+  # the grpc targets directly from this build.
+  set(_PROTOBUF_LIBPROTOBUF libprotobuf)
+  set(_REFLECTION grpc++_reflection)
+  set(_PROTOBUF_PROTOC $<TARGET_FILE:protoc>)
+  set(_GRPC_GRPCPP grpc++)
+  if(CMAKE_CROSSCOMPILING)
+    find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+  else()
+    set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:grpc_cpp_plugin>)
+  endif()
+else()
+  # This branch assumes that gRPC and all its dependencies are already installed
+  # on this system, so they can be located by find_package().
+
+  # Find Protobuf installation
+  # Looks for protobuf-config.cmake file installed by Protobuf's cmake installation.
+  set(protobuf_MODULE_COMPATIBLE TRUE)
+  find_package(Protobuf CONFIG REQUIRED)
+  message(STATUS "Using protobuf ${Protobuf_VERSION}")
+
+  set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
+  set(_REFLECTION gRPC::grpc++_reflection)
+  if(CMAKE_CROSSCOMPILING)
+    find_program(_PROTOBUF_PROTOC protoc)
+  else()
+    set(_PROTOBUF_PROTOC $<TARGET_FILE:protobuf::protoc>)
+  endif()
+
+  # Find gRPC installation
+  # Looks for gRPCConfig.cmake file installed by gRPC's cmake installation.
+  find_package(gRPC CONFIG REQUIRED)
+  message(STATUS "Using gRPC ${gRPC_VERSION}")
+
+  set(_GRPC_GRPCPP gRPC::grpc++)
+  if(CMAKE_CROSSCOMPILING)
+    find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+  else()
+    set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
+  endif()
+endif()

--- a/server/common/plog.h
+++ b/server/common/plog.h
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * FILENAME:      plog.h
+ *
+ * AUTHORS:       Shen Qi
+ *
+ * START DATE:    Thursday April 14th 2022
+ *
+ * CONTACT:       qi.shen@smartmore.com
+ ******************************************************************************/
+
+#ifndef SMARTMORE_SCC_PLOG_H
+#define SMARTMORE_SCC_PLOG_H
+
+// conflict with tensor-src/include/tensor/tensor_log.h
+
+#undef LOG_INFO
+#undef LOG_DEBUG
+#undef LOG_WARN
+#undef LOG_ERROR
+
+#include <plog/Log.h>
+
+#undef LOG_INFO
+#undef LOG_DEBUG
+#undef LOG_WARN
+#undef LOG_ERROR
+
+#endif  // SMARTMORE_SCC_PLOG_H

--- a/server/grpc_server.cpp
+++ b/server/grpc_server.cpp
@@ -1,0 +1,143 @@
+#include "grpc_server.h"
+
+#include <grpcpp/support/status.h>
+#include <opencv2/core/hal/interface.h>
+
+#include <memory>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/opencv.hpp>
+
+#include "algointerface.pb.h"
+#include "blob_sdk.h"
+#include "common/plog.h"
+#include "plog/Log.h"
+
+namespace smartmore
+{
+namespace huaxing
+{
+namespace server
+{
+
+cv::Mat ConvertImageToMat(algointerface::Image img)
+{
+    int c = img.channels();
+    int w = img.height();
+    int h = img.width();
+
+    return cv::Mat(w, h, CV_8UC(c), static_cast<void*>(const_cast<char*>(img.data().data())));
+}
+
+bool ConvertBytesToMat(const std::string& str, cv::Mat& mat, int flags)
+{
+    int n_size = str.size();
+    const char* ptr_buffer = str.data();
+    cv::Mat raw_data(1, n_size, CV_8UC1, static_cast<void*>(const_cast<char*>(ptr_buffer)));
+    mat = cv::imdecode(raw_data, flags);
+    if (mat.data == nullptr)
+    {
+        PLOGE << "Convert Bytes to cvMat Failed";
+        return false;
+    }
+    return true;
+}
+
+class InferImpl
+{
+   public:
+    explicit InferImpl() : module_(std::make_shared<smartmore::blob::BlobSDK>()) {}
+    virtual smartmore::blob::ResultCode Init()
+    {
+        if (module_ == nullptr)
+        {
+            PLOGE << "sdk module is null";
+            return smartmore::blob::ResultCode::INTERNAL_ERROR;
+        }
+        auto res = module_->Init();
+        if (res != smartmore::blob::ResultCode::SUCCESS)
+        {
+            PLOGE << "sdk init failed";
+        }
+        else
+        {
+            PLOGI << "sdk init succeed";
+        }
+
+        return res;
+    }
+
+    virtual smartmore::blob::ResultCode Run(const smartmore::blob::Request& req,
+                                            smartmore::blob::Response& rsp)
+    {
+        if (module_ == nullptr)
+        {
+            PLOGE << "sdk module is null";
+            return smartmore::blob::ResultCode::INTERNAL_ERROR;
+        }
+
+        auto res = module_->Run(req, rsp);
+        if (res != smartmore::blob::ResultCode::SUCCESS)
+        {
+            PLOGE << "sdk run failed";
+        }
+        else
+        {
+            PLOGI << "sdk run succeed";
+        }
+
+        return res;
+    }
+
+   private:
+    std::shared_ptr<smartmore::blob::BlobSDK> module_;
+};
+
+AsyncServer::AsyncServer(bool use_gpu) : use_gpu_(use_gpu), impl_(std::make_shared<InferImpl>())
+{
+    auto res = impl_->Init();
+    if (res != smartmore::blob::ResultCode::SUCCESS)
+    {
+        PLOGE << "color sdk init failed";
+    }
+    else
+    {
+        PLOGI << "color sdk init succeed";
+    }
+}
+AsyncServer::~AsyncServer() {}
+Status AsyncServer::AlgoInferRun(ServerContext* context, const algointerface::AlgoInferReq* request,
+                                 algointerface::AlgoInferRsp* response)
+{
+    if (request->has_image())
+    {
+        if (request->image().data().empty())
+        {
+            PLOGE << "algo server error: input image is empty!";
+            return Status::CANCELLED;
+        }
+    }
+
+    smartmore::blob::Request req{ConvertImageToMat(request->image()), request->threshold()};
+    smartmore::blob::Response rsp;
+
+    impl_->Run(req, rsp);
+
+    response->Clear();
+
+    for (auto& cont : rsp.contours)
+    {
+        auto contour = response->add_contours();
+        for (auto& pt : cont)
+        {
+            auto point = contour->add_pts();
+            point->set_x(pt.x);
+            point->set_y(pt.y);
+        }
+    }
+
+    return Status::OK;
+}
+
+}  // namespace server
+}  // namespace huaxing
+}  // namespace smartmore

--- a/server/grpc_server.h
+++ b/server/grpc_server.h
@@ -1,0 +1,48 @@
+#ifndef INCLUDE_HUAXING_RPC_SERVER
+#define INCLUDE_HUAXING_RPC_SERVER
+
+#include <grpc++/alarm.h>
+#include <grpc++/grpc++.h>
+#include <grpc/grpc.h>
+#include <grpcpp/support/status.h>
+
+#include <memory>
+
+#include "algointerface.grpc.pb.h"
+
+namespace smartmore
+{
+namespace huaxing
+{
+namespace server
+{
+
+using algointerface::AlgoEngine;
+using algointerface::AlgoInferReq;
+using algointerface::AlgoInferRsp;
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerContext;
+using grpc::Status;
+
+class InferImpl;
+
+class AsyncServer final : public algointerface::AlgoEngine::Service
+{
+   public:
+    explicit AsyncServer(bool use_gpu);
+    Status AlgoInferRun(ServerContext* context, const algointerface::AlgoInferReq* request,
+                        algointerface::AlgoInferRsp* response) override;
+
+    ~AsyncServer();
+
+   private:
+    bool use_gpu_ = false;  //暂时没有用上
+    std::shared_ptr<InferImpl> impl_;
+};
+
+}  // namespace server
+}  // namespace huaxing
+}  // namespace smartmore
+
+#endif

--- a/server/proto/algointerface.proto
+++ b/server/proto/algointerface.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package algointerface;
+
+service  AlgoEngine {
+    rpc AlgoInferRun(AlgoInferReq) returns(AlgoInferRsp) {}
+}
+
+
+message Image
+{
+    int32 width = 1;
+    int32 height = 2;
+    int32 channels = 3;
+    bytes data = 4;
+}
+
+message Point
+{
+    int32 x = 1;
+    int32 y = 2;
+}
+
+message Contour
+{
+    repeated Point pts = 1;
+}
+
+message AlgoInferReq
+{
+    float threshold = 1;
+    Image image = 2;    //输入图像
+}
+
+message AlgoInferRsp {
+    repeated Contour contours = 1;
+}


### PR DESCRIPTION
实现了grpc server，调用blob sdk完成run操作。需要注意：
1. 正确编译需要按之前的步骤安装好grpc
2. /server/cmake/common.cmake 是grpc的example拿过来的，它帮你构建了C++相关编译工具，protobuff工具等。一般来说不需要修改
3. /server/CMakeLists.txt 是基于模板创建的。里面定义了protobuf自动生成的代码位置。
4. /server/proto 里面是接口，.proto后缀的文件是接口文件。Google的protobuf会根据这个文件自动生成cpp代码参与编译

接下来是编写测试代码，测试服务以及通信